### PR TITLE
Do not use deprecated method github.com/prometheus/common/version.NewCollector

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus-community/postgres_exporter/collector"
 	"github.com/prometheus-community/postgres_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
+	cversion "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
@@ -122,7 +123,7 @@ func main() {
 		exporter.servers.Close()
 	}()
 
-	prometheus.MustRegister(version.NewCollector(exporterName))
+	prometheus.MustRegister(cversion.NewCollector(exporterName))
 
 	prometheus.MustRegister(exporter)
 


### PR DESCRIPTION
Method `github.com/prometheus/common/version.NewCollector` was deprecated and removed in the latest version.

This PR replaces the usage of the deprecated method with `github.com/prometheus/client_golang/prometheus/collectors/version.NewCollector`. 

- https://github.com/prometheus/common/commit/9fbe2ed2e64ecf4828eb2a7ee9fed95816b50b03