### PR TITLE
fix: Always close database connections

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -142,6 +142,7 @@ func main() {
 	if err != nil {
 		level.Warn(logger).Log("msg", "Failed to create PostgresCollector", "err", err.Error())
 	} else {
+		defer pe.Close()
 		prometheus.MustRegister(pe)
 	}
 

--- a/cmd/postgres_exporter/server.go
+++ b/cmd/postgres_exporter/server.go
@@ -169,6 +169,7 @@ func (s *Servers) GetServer(dsn string) (*Server, error) {
 			s.servers[dsn] = server
 		}
 		if err = server.Ping(); err != nil {
+			server.Close()
 			delete(s.servers, dsn)
 			time.Sleep(time.Duration(errCount) * time.Second)
 			continue

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -172,11 +172,11 @@ func (p PostgresCollector) Collect(ch chan<- prometheus.Metric) {
 
 	// Set up the database connection for the collector.
 	err := inst.setup()
+	defer inst.Close()
 	if err != nil {
 		level.Error(p.logger).Log("msg", "Error opening connection to database", "err", err)
 		return
 	}
-	defer inst.Close()
 
 	wg := sync.WaitGroup{}
 	wg.Add(len(p.Collectors))
@@ -187,6 +187,10 @@ func (p PostgresCollector) Collect(ch chan<- prometheus.Metric) {
 		}(name, c)
 	}
 	wg.Wait()
+}
+
+func (p *PostgresCollector) Close() error {
+	return p.instance.Close()
 }
 
 func execute(ctx context.Context, name string, c Collector, instance *instance, ch chan<- prometheus.Metric, logger log.Logger) {

--- a/collector/probe.go
+++ b/collector/probe.go
@@ -77,11 +77,11 @@ func (pc *ProbeCollector) Describe(ch chan<- *prometheus.Desc) {
 func (pc *ProbeCollector) Collect(ch chan<- prometheus.Metric) {
 	// Set up the database connection for the collector.
 	err := pc.instance.setup()
+	defer pc.instance.Close()
 	if err != nil {
 		level.Error(pc.logger).Log("msg", "Error opening connection to database", "err", err)
 		return
 	}
-	defer pc.instance.Close()
 
 	wg := sync.WaitGroup{}
 	wg.Add(len(pc.collectors))


### PR DESCRIPTION
A user of grafana's alloy agent noticed ( https://github.com/grafana/alloy/issues/1929 ) a goroutine leak when utilizing the postgres exporter with an inaccessible postgres database. This PR appropriately closes any of the database connections that are opened, preventing the leak.

To test, I just ran the exporter using a configuration that was not valid (no postgres running on my machine), and in another terminal curled it repeatedly, monitoring the goroutine count being returned from the prometheus metrics endpoint. Running this test can very quickly show the leak, and that a build from this PR resolves the issue.

```
DATA_SOURCE_NAME="user=postgres host=/var/run/postgresql/ sslmode=disable" ./postgres_exporter

---

while true; do curl http://localhost:9187/metrics | grep goroutine; done

```