### PR TITLE
Change tooltip mode from 'multi' to 'single'

### DIFF
--- a/postgres_mixin/dashboards/postgresql-overview.json
+++ b/postgres_mixin/dashboards/postgresql-overview.json
@@ -246,7 +246,7 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
@@ -619,7 +619,7 @@
           "showLegend": false
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
@@ -995,7 +995,7 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
@@ -1193,7 +1193,7 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },


### PR DESCRIPTION
if you have a lot of series in the widgets, then the multi-label tooltip mode can be very overloaded. Better switch it to single, so you only get the label for the line over which you're hovering